### PR TITLE
Merchant items most popular

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,10 +2,20 @@ class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
+  has_many :transactions, through: :invoices
 
   validates_presence_of :name, :description, :unit_price, :merchant_id
 
   enum status: [:disabled, :enabled]
+
+  def self.most_popular_items
+    select("items.*, SUM(invoice_items.quantity * invoice_items.unit_price) AS revenue").
+    joins(:invoice_items, :transactions).
+    where(transactions: {result: "success"}).
+    order(revenue: :desc).
+    limit(5).
+    group(:id)
+  end
 
   def self.ordered_items_no_ship
     joins(:invoice_items).where('status != ?', 2)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,14 +6,6 @@ class Merchant < ApplicationRecord
   has_many :customers, through: :invoices
 
   validates_presence_of :name
-
-
-  def most_popular_items
-    joins(:items).
-    select("merchants.name, max(unit_price) as max_unit_price").
-    group(:id)
-    #I need to add a limit of 5 somewhere
-
   enum status: [:disabled, :enabled]
 
   def self.disabled_merchants

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -19,3 +19,12 @@
     </li>
   <% end %>
 </ul>
+
+<h3>Top Items</h3>
+<ol>
+  <% @items.most_popular_items.each do |item| %>
+    <li id="top-item-<%= item.id %>">
+      <%= link_to "#{item.name}", "/merchant/#{@merchant.id}/items/#{item.id}" %> - <%= number_to_currency(item.revenue) %>
+    </li>
+  <% end %>
+</ol>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 
 <section>
   <p>Description: <%= @item.description %></p>
-  <p>Current Price: $<%= @item.unit_price %>.00</p>
+  <p>Current Price: <%= number_to_currency(@item.unit_price) %></p>
 </section><br>
 
 <%= link_to "Update Item", "/merchant/#{@merchant.id}/items/#{@item.id}/edit", method: :get %>

--- a/spec/features/merchants/items_index_spec.rb
+++ b/spec/features/merchants/items_index_spec.rb
@@ -29,24 +29,29 @@ RSpec.describe "Merchant item index page" do
     end
   end
 
-  # it 'can click on enable and it updates item status to enable' do
-  #   within("#disabled-item-#{@item_1.id}") do
-  #     click_button "Enable"
-  #   end
-  #   expect(current_path).to eq("/merchant/#{@merchant_1.id}/items")
-  #   expect(@item_1.status).to eq("enabled")
-  # end
-  #
-  # it 'can click on disable and it updates item status to disabled' do
-  #   @item_1.update!(status: 1)
-  #
-  #   within("#enabled-item-#{@item_1.id}") do
-  #     click_button "Disable"
-  #   end
-  #
-  #   expect(current_path).to eq("/merchant/#{@merchant_1.id}/items")
-  #   expect(@item_1.status).to eq("disabled")
-  # end
+  it 'can click on enable and it updates item status to enable' do
+    within("#disabled-item-#{@item_1.id}") do
+      click_button "Enable"
+    end
+
+    expect(current_path).to eq("/merchant/#{@merchant_1.id}/items")
+
+    within("#enabled-item-#{@item_1.id}") do
+      expect(page).to have_button("Disable")
+    end
+  end
+
+  it 'can click on disable and it updates item status to disabled' do
+    within("#enabled-item-#{@item_2.id}") do
+      click_button "Disable"
+    end
+
+    expect(current_path).to eq("/merchant/#{@merchant_1.id}/items")
+
+    within("#disabled-item-#{@item_2.id}") do
+      expect(page).to have_button("Enable")
+    end
+  end
 
   it 'shows a link to create a new item that I can click on' do
     expect(page).to have_link("Create New Item")
@@ -65,5 +70,12 @@ RSpec.describe "Merchant item index page" do
     click_button "Submit"
 
     expect(current_path).to eq("/merchant/#{@merchant_1.id}/items")
+  end
+
+  it 'shows a section for my top five items by revenue' do
+    expect(page).to have_content("Top Items")
+    #update to include revenue and names, need to add
+    #invoice_items and transactions to the before each
+    #want to use factory bot for the sake of time 
   end
 end

--- a/spec/models/items_spec.rb
+++ b/spec/models/items_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Item, type: :model do
       @customer = Customer.create!(first_name: 'Stuart', last_name: 'Little')
       @invoice_1 = Invoice.create!(status: 0, customer_id: "#{@customer.id}")
       @invoice_2 = Invoice.create!(status: 0, customer_id: "#{@customer.id}")
+      @transaction_1 = @invoice_1.transactions.create!(credit_card_number: "123", credit_card_expiration_date: 0, result: "success")
+      @transaction_2 = @invoice_2.transactions.create!(credit_card_number: "123", credit_card_expiration_date: 1, result: "failed")
       InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 3, unit_price: 40, status: 0)
       InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_2.id, quantity: 10, unit_price: 20, status: 2)
     end
@@ -45,6 +47,14 @@ RSpec.describe Item, type: :model do
       it 'finds rows where items are enabled' do
         expect(Item.enabled_items).to eq([@item_2, @item_3])
         expect(Item.enabled_items).to_not eq([@item_1, @item_4])
+      end
+    end
+
+    describe '::most_popular_items' do
+      it 'finds the top five items by revenue for a merchant' do
+        expect(Item.most_popular_items).to eq([@item_1])
+        expect(Item.most_popular_items).to_not eq([@item_2])
+        #Return to add four more items when factory bot is set-up
       end
     end
   end


### PR DESCRIPTION
Merchant Items Index: 5 most popular items

As a merchant
When I visit my items index page
Then I see the names of the top 5 most popular items ranked by total revenue generated
And I see that each item name links to my merchant item show page for that item
And I see the total revenue generated next to each item name

Notes on Revenue Calculation:
- Only invoices with at least one successful transaction should count towards revenue
- Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
- Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)